### PR TITLE
Récupération des dernières conversations sur l'intra

### DIFF
--- a/etnawrapper/constants.py
+++ b/etnawrapper/constants.py
@@ -20,3 +20,5 @@ GSA_LOGS_URL = GSA_API + "/students/{login}/logs"
 
 EVENTS_URL = INTRA_API + "/students/{login}/events?end={end_date}&start={start_date}"
 DECLARATION_URL = INTRA_API + "/modules/{module_id}/declareLogs"
+
+CONVERSATIONS_URL = INTRA_API + "/users/{user_id}/conversations"

--- a/etnawrapper/etna.py
+++ b/etnawrapper/etna.py
@@ -201,6 +201,17 @@ class EtnaWrapper:
         result = self._query(url)
         return result
 
+    def get_conversations(self, user_id: int) -> dict:
+        """Return the list of conversations for a user.
+
+        Requires read permission for this user_id.
+        Use this method with a user_id corresponding to your login
+        to ensure readability.
+        """
+        url = CONVERSATIONS_URL.format(user_id=user_id)
+        result = self._query(url)
+        return(result)
+
     def declare_log(self, module_id: int, content: dict):
         """Send a log declaration for module_id with `content`.
 
@@ -224,14 +235,6 @@ class EtnaWrapper:
         result = self._query(url, method='OPTIONS', raw=True)
         result = self._query(url, method='POST', data=content)
         return result
-
-    def get_latests_conversations(self, user_id: int = None) -> dict:
-        """Return the list of conversations for a user."""
-        url = CONVERSATIONS_URL
-        if user_id is not None:
-            url = CONVERSATIONS_URL.format(user_id=user_id)
-        result = self._query(url)
-        return(result)
 
 
 __all__ = ("EtnaWrapper",)

--- a/etnawrapper/etna.py
+++ b/etnawrapper/etna.py
@@ -26,6 +26,7 @@ from .constants import (
     GSA_LOGS_URL,
     EVENTS_URL,
     DECLARATION_URL,
+    CONVERSATIONS_URL,
 )
 
 
@@ -223,6 +224,14 @@ class EtnaWrapper:
         result = self._query(url, method='OPTIONS', raw=True)
         result = self._query(url, method='POST', data=content)
         return result
+
+    def get_latests_conversations(self, user_id: int = None) -> dict:
+        """Return the list of posts for a user."""
+        url = CONVERSATIONS_URL
+        if user_id is not None:
+            url = CONVERSATIONS_URL.format(user_id=user_id)
+        result = self._query(url)
+        return(result)
 
 
 __all__ = ("EtnaWrapper",)

--- a/etnawrapper/etna.py
+++ b/etnawrapper/etna.py
@@ -226,7 +226,7 @@ class EtnaWrapper:
         return result
 
     def get_latests_conversations(self, user_id: int = None) -> dict:
-        """Return the list of posts for a user."""
+        """Return the list of conversations for a user."""
         url = CONVERSATIONS_URL
         if user_id is not None:
             url = CONVERSATIONS_URL.format(user_id=user_id)


### PR DESCRIPTION
Hello,
cette PR ajoute la possibilité de lister les dernières conversations sur l'intra.

Voici un exemple: 

```
#!/usr/bin/env python3

from etnawrapper import EtnaWrapper
import json

wrapper = EtnaWrapper(login='user', password='passwd')

data = json.dumps(wrapper.get_latests_conversations(user_id=user_id))

with open("file.json", 'w') as f :
	f.write(data)

with open("file.json", 'r') as f:
	json_data = json.load(f)

	for i in range(len(json_data)):
		print(json_data['hits'][i]['title'])
```
Demo :
```
$ python3 demo.py
Correction de l'étape: 02_proper_exec
Correction de l'étape: 01_exec_cmd
Correction de l'étape: 08_flask_storage
Correction de l'étape: 07_putting_it_all_together
Correction de l'étape: 06_flask_data
```