### PR TITLE
Liste des déclarations de temps de travail

### DIFF
--- a/etnawrapper/constants.py
+++ b/etnawrapper/constants.py
@@ -20,5 +20,6 @@ GSA_LOGS_URL = GSA_API + "/students/{login}/logs"
 
 EVENTS_URL = INTRA_API + "/students/{login}/events?end={end_date}&start={start_date}"
 DECLARATION_URL = INTRA_API + "/modules/{module_id}/declareLogs"
+DECLARATIONS_URL = GSA_API + "/students/{login}/declarations"
 
 CONVERSATIONS_URL = INTRA_API + "/users/{user_id}/conversations"

--- a/etnawrapper/etna.py
+++ b/etnawrapper/etna.py
@@ -219,7 +219,7 @@ class EtnaWrapper:
         result = self._query(url, params=params)
         return(result)
 
-    def get_declarations(self, login: str = None, start: str = None, end: str = None, size: int = None) -> dict:
+    def get_declarations(self, login: str = None, start: str = None, end: str = None) -> dict:
         """Return the list of declarations for a user.
 
         Requires read permission for this login.
@@ -230,8 +230,6 @@ class EtnaWrapper:
             params['start'] = start
         if end is not None:
             params['end'] = end
-        if size is not None:
-            params['size'] = size
         result = self._query(url, params=params)
         return(result)
 

--- a/etnawrapper/etna.py
+++ b/etnawrapper/etna.py
@@ -217,7 +217,7 @@ class EtnaWrapper:
         if size is not None:
             params['size'] = size
         result = self._query(url, params=params)
-        return(result)
+        return result
 
     def get_declarations(self, start: str = None, end: str = None) -> dict:
         """Return the list of declarations for a user.
@@ -231,7 +231,7 @@ class EtnaWrapper:
         if end is not None:
             params['end'] = end
         result = self._query(url, params=params)
-        return(result)
+        return result
 
     def declare_log(self, module_id: int, content: dict):
         """Send a log declaration for module_id with `content`.

--- a/etnawrapper/etna.py
+++ b/etnawrapper/etna.py
@@ -26,6 +26,7 @@ from .constants import (
     GSA_LOGS_URL,
     EVENTS_URL,
     DECLARATION_URL,
+    DECLARATIONS_URL,
     CONVERSATIONS_URL,
 )
 
@@ -213,6 +214,22 @@ class EtnaWrapper:
         params = dict()
         if start is not None:
             params['start'] = start
+        if size is not None:
+            params['size'] = size
+        result = self._query(url, params=params)
+        return(result)
+
+    def get_declarations(self, login: str = None, start: str = None, end: str = None, size: int = None) -> dict:
+        """Return the list of declarations for a user.
+
+        Requires read permission for this login.
+        """
+        url = DECLARATIONS_URL.format(login=self.login)
+        params = dict()
+        if start is not None:
+            params['start'] = start
+        if end is not None:
+            params['end'] = end
         if size is not None:
             params['size'] = size
         result = self._query(url, params=params)

--- a/etnawrapper/etna.py
+++ b/etnawrapper/etna.py
@@ -219,7 +219,7 @@ class EtnaWrapper:
         result = self._query(url, params=params)
         return(result)
 
-    def get_declarations(self, login: str = None, start: str = None, end: str = None) -> dict:
+    def get_declarations(self, start: str = None, end: str = None) -> dict:
         """Return the list of declarations for a user.
 
         Requires read permission for this login.


### PR DESCRIPTION
Salut Théo :)
cette PR ajoute un moyen  lister les déclarations de temps de travail.

Pour les tests : 
```python
import requests
import json
from etnawrapper import EtnaWrapper

w = EtnaWrapper(login=etna_id, password=etna_passwd)

declarations = w.get_declarations(start="2019-06-13", end="2019-06-14")
data = json.loads(json.dumps(declarations))

for i in range(len(data)):
    print("=== %d ===" % i)
    print("start : %s" % data['hits'][i]['start'])
    print("end  : %s" % data['hits'][i]['end'])
    print("description :\n%s" % data['hits'][i]['metas']['description'])
```

Result : 
```
=== 0 ===
start : 2019-06-14T13:30:00+02:00
end   : 2019-06-14T17:30:00+02:00
description :
- Objectifs: préparation de l'anglais

- Actions: lire le sujet et le comprendre

- Résultats: je sais quoi faire maintenant

=== 1 ===
start : 2019-06-13T13:30:00+02:00
end   : 2019-06-13T17:30:00+02:00
description :
- Objectifs: continuer le XSS

- Actions: lecture de doc sur le XSS

- Résultats: Aucun resultat.
```