### PR TITLE
Ouverture d'un ticket sur l'intra

### DIFF
--- a/etnawrapper/constants.py
+++ b/etnawrapper/constants.py
@@ -3,6 +3,7 @@ ETNA_API = "https://auth.etna-alternance.net"
 AUTH_URL = "https://auth.etna-alternance.net/login"
 MODULE_API = "https://modules-api.etna-alternance.net"
 GSA_API = "https://gsa-api.etna-alternance.net"
+TICKET_API = "https://tickets.etna-alternance.net"
 
 IDENTITY_URL = ETNA_API + "/identity"
 USER_INFO_URL = ETNA_API + "/api/users/{user_id}"
@@ -23,3 +24,5 @@ DECLARATION_URL = INTRA_API + "/modules/{module_id}/declareLogs"
 DECLARATIONS_URL = GSA_API + "/students/{login}/declarations"
 
 CONVERSATIONS_URL = INTRA_API + "/users/{user_id}/conversations"
+
+TICKET_URL = TICKET_API + "/api/tasks.json"

--- a/etnawrapper/etna.py
+++ b/etnawrapper/etna.py
@@ -4,7 +4,7 @@
 # TODO: Cli ? :o
 # TODO: CLI.
 from datetime import datetime
-from typing import Union
+from typing import Union, List
 from io import BytesIO
 
 import requests
@@ -258,25 +258,13 @@ class EtnaWrapper:
         result = self._query(url, method='POST', data=content)
         return result
 
-    def open_ticket(self, content: dict):
-        """Open a ticket.
-        >>> content = {
-                "tags":[
-                    "pedago",
-                    "suivi",
-                    "retard"
-                ],
-                "users":[
-                   {
-                      "role":"student",
-                      "login":"logi_n",
-                      "email":"user@mail.net"
-                   }
-                ],
-                "title": "I'm going to be late",
-                "message": "Sorry I'm late"
-            }
-        """
+    def open_ticket(self, title: str, message: str, tags: List[str] = None, users: List[str] = None):
+        """Open a ticket."""
+        content = {}
+        content['title'] = title
+        content['message'] = message
+        content['tags'] = tags
+        content['users'] = users
 
         url = TICKET_URL
         result = self._query(url, method='OPTIONS', raw=True)

--- a/etnawrapper/etna.py
+++ b/etnawrapper/etna.py
@@ -28,6 +28,7 @@ from .constants import (
     DECLARATION_URL,
     DECLARATIONS_URL,
     CONVERSATIONS_URL,
+    TICKET_URL,
 )
 
 
@@ -255,6 +256,32 @@ class EtnaWrapper:
         )
         result = self._query(url, method='OPTIONS', raw=True)
         result = self._query(url, method='POST', data=content)
+        return result
+
+    def open_ticket(self, content: dict):
+        """Open a ticket.
+        >>> content = {
+                "tags":[
+                    "pedago",
+                    "suivi",
+                    "retard"
+                ],
+                "users":[
+                   {
+                      "role":"student",
+                      "login":"logi_n",
+                      "email":"user@mail.net"
+                   }
+                ],
+                "title": "I'm going to be late",
+                "message": "Sorry I'm late"
+            }
+        """
+
+        url = TICKET_URL
+        result = self._query(url, method='OPTIONS', raw=True)
+        result = self._query(url, method='POST', data=content)
+
         return result
 
 


### PR DESCRIPTION
Yo Theo,

voici une PR, pour pouvoir créer un ticket sur l'intra: 
Pour les tests : 
```python
#!/usr/bin/env python3

import os
from etnawrapper import EtnaWrapper

content = {
       "tags":[
           "pedago",
           "suivi",
           "retard"
       ],
       "users": [],
       "title": "Retard",
       "message": "Bonjour,\nJe vais etre en retard\n Cordialement."
}

etna_id = os.getenv('ETNA_USER')
etna_passwd = os.getenv('ETNA_PASSWORD')

w = EtnaWrapper(login=etna_id, password=etna_passwd)
w.open_ticket(content)
```
Résultat : Ca ouvre un ticket sur l'intra.

