### PR TITLE
liste des modules d'après une date

### DIFF
--- a/etnawrapper/etna.py
+++ b/etnawrapper/etna.py
@@ -165,9 +165,11 @@ class EtnaWrapper:
         result = self._query(url, raw=True)
         return result.content
 
-    def get_projects(self, login: str = None) -> dict:
+    def get_projects(self, login: str = None, date: datetime = None) -> dict:
         """Fetch a student's projects base on the login."""
         url = SEARCH_URL.format(login=login or self.login)
+        if date is not None:
+            url += "?date=" + date
         result = self._query(url)
         return result
 

--- a/etnawrapper/etna.py
+++ b/etnawrapper/etna.py
@@ -168,9 +168,11 @@ class EtnaWrapper:
     def get_projects(self, login: str = None, date: datetime = None) -> dict:
         """Fetch a student's projects base on the login."""
         url = SEARCH_URL.format(login=login or self.login)
+        params = dict()
         if date is not None:
-            url += "?date=" + date
-        result = self._query(url)
+            _date = date.strftime('%Y-%m-%d')
+            params["date"] = _date
+        result = self._query(url, params=params)
         return result
 
     def get_project_activites(self, module: str) -> dict:


### PR DESCRIPTION
Hello, 
nouvelle PR pour lister les modules d'après une date donnée. C'est ce qu'utilise le form du temps de travail pour lister les modules sur lesquels on a le droit de déclarer.

Voici ce que ça donne avec la date du 11/05
```
>>> from etnawrapper import EtnaWrapper
>>> w = EtnaWrapper(login='', password='')
>>> projects = w.get_projects(date='2020-05-11')
>>> for i,_ in enumerate(projects):
...     print(projects[i]['date_end'])
... 
2020-10-16 17:00:00
2020-05-22 23:42:00
2020-10-04 23:42:00
2020-11-06 23:42:00
2021-10-08 17:00:00
2022-12-31 23:42:00
2020-05-22 23:42:00
2020-09-18 23:42:00
2021-10-08 17:00:00
```
